### PR TITLE
test: removing a final TODO

### DIFF
--- a/patch-tracing-channel.js
+++ b/patch-tracing-channel.js
@@ -98,7 +98,7 @@ module.exports = function (unpatched) {
         context.error = err;
         error.publish(context);
         asyncStart.publish(context);
-        // TODO: Is there a way to have asyncEnd _after_ the continuation?
+
         asyncEnd.publish(context);
         return PromiseReject(err);
       }
@@ -106,7 +106,7 @@ module.exports = function (unpatched) {
       function resolve(result) {
         context.result = result;
         asyncStart.publish(context);
-        // TODO: Is there a way to have asyncEnd _after_ the continuation?
+
         asyncEnd.publish(context);
         return result;
       }

--- a/test/test-diagnostics-channel-bind-store.spec.js
+++ b/test/test-diagnostics-channel-bind-store.spec.js
@@ -54,17 +54,18 @@ test('test-diagnostics-channel-bind-store', t => {
 
     // Should support nested contexts
     n++;
-    channel.runStores(inputs[n], common.mustCall(function() {
+    const fn = common.mustCall(()=>{});
+    channel.runStores(inputs[n], function() {
+      fn();
       // Verify this and argument forwarding
-      // TODO: For some reason `this` === `global`. Seems like a bug in common.mustCall?
-      // t.strictEqual(this, undefined);
+      t.strictEqual(this, undefined);
 
       // Verify store 1 state matches input
       t.strictEqual(store1.getStore(), inputs[n]);
 
       // Verify store 2 state has expected transformation
       t.deepEqual(store2.getStore(), { data: inputs[n] });
-    }));
+    });
     n--;
 
     // Verify store 1 state matches input


### PR DESCRIPTION
- only a final TODO entry remained
- I had presumed this was an issue with mustCall but wanted to confirm