### PR TITLE
remove unnecessary patching for Node.js v20.0-v20.5

### DIFF
--- a/checks.js
+++ b/checks.js
@@ -21,7 +21,7 @@ function hasDiagnosticsChannel() {
 module.exports.hasDiagnosticsChannel = hasDiagnosticsChannel;
 
 function hasTopSubscribeUnsubscribe() {
-  return hasFullSupport()
+  return MAJOR >= 20
     || (MAJOR === 16 && MINOR >= 17)
     || (MAJOR === 18 && MINOR >= 7);
 }

--- a/checks.js
+++ b/checks.js
@@ -9,7 +9,7 @@ function hasFullSupport() {
 module.exports.hasFullSupport = hasFullSupport;
 
 function hasTracingChannel() {
-  return hasFullSupport();
+  return MAJOR >= 20;
 }
 module.exports.hasTracingChannel = hasTracingChannel;
 

--- a/checks.js
+++ b/checks.js
@@ -38,7 +38,7 @@ function hasZeroSubscribersBug() {
 module.exports.hasZeroSubscribersBug = hasZeroSubscribersBug;
 
 function hasChannelStoreMethods() {
-  return hasFullSupport()
+  return MAJOR === 20
     || (MAJOR === 19 && MINOR >= 9);
 }
 module.exports.hasChannelStoreMethods = hasChannelStoreMethods;

--- a/test/test-diagnostics-channel-tracing-channel-async.spec.js
+++ b/test/test-diagnostics-channel-tracing-channel-async.spec.js
@@ -57,7 +57,7 @@ test('test-diagnostics-channel-tracing-channel-async', (t) => {
   try {
     channel.traceCallback(common.mustNotCall(), 0, input, thisArg, 1, 2, 3);
   } catch (err) {
-    if (MAJOR >= 20 && MINOR >= 6) {
+    if (MAJOR >= 20) {
       // By default, this error message is used for all of v20
       // However, patch-sync-unsubscribe-bug causes the error to change to the older version mentioning Array
       t.ok(/"callback" argument must be of type function/.test(err.message));


### PR DESCRIPTION
- the definition of `hasFullSupport` changed from >= v20 to >= v20.6
  - this resulted in the store methods being patched for v20.0 to v20.5
  - same with tracing channel and top subscribe/unsubscribe
- these versions don't need to be patched so dc-polyfill is doing unnecessary work