### PR TITLE
Reordering polyfill conditionals

### DIFF
--- a/checks.js
+++ b/checks.js
@@ -3,6 +3,8 @@ module.exports.MAJOR = MAJOR;
 module.exports.MINOR = MINOR;
 module.exports.PATCH = PATCH;
 
+module.exports.VERSION = `${MAJOR}.${MINOR}`
+
 function hasFullSupport() {
   return MAJOR > 20 || (MAJOR >= 20 && MINOR >= 6);
 }

--- a/checks.js
+++ b/checks.js
@@ -41,7 +41,8 @@ module.exports.hasZeroSubscribersBug = hasZeroSubscribersBug;
 
 function hasChannelStoreMethods() {
   return MAJOR >= 20
-    || (MAJOR === 19 && MINOR >= 9);
+  || (MAJOR === 18 && MINOR >= 19)
+  || (MAJOR === 19 && MINOR >= 9);
 }
 module.exports.hasChannelStoreMethods = hasChannelStoreMethods;
 

--- a/dc-polyfill.js
+++ b/dc-polyfill.js
@@ -19,7 +19,7 @@ if (!checks.hasChUnsubscribeReturn()) {
   dc = require('./patch-channel-unsubscribe-return.js')(dc);
 }
 
-if ((VERSION < 18.19) || (VERSION >= 19.0 && VERSION < 19.8)) {
+if ((!VERSION === 18.6 || 18.7) || (VERSION < 18.19) || (VERSION >= 19.0 && VERSION <= 19.8)) {
   if (!checks.hasChannelStoreMethods()) {
     dc = require('./patch-channel-store-methods.js')(dc);
   }

--- a/dc-polyfill.js
+++ b/dc-polyfill.js
@@ -18,10 +18,6 @@ if (!checks.hasChUnsubscribeReturn()) {
   dc = require('./patch-channel-unsubscribe-return.js')(dc);
 }
 
-if (!checks.hasChannelStoreMethods()) {
-  dc = require('./patch-channel-store-methods.js')(dc);
-}
-
 if (!checks.hasTracingChannel()) {
   dc = require('./patch-tracing-channel.js')(dc);
 }
@@ -32,6 +28,10 @@ if (checks.hasSyncUnsubscribeBug()) {
 
 if (!checks.hasTracingChannelHasSubscribers()) {
   dc = require('./patch-tracing-channel-has-subscribers.js')(dc);
+}
+
+if (!checks.hasChannelStoreMethods()) {
+  dc = require('./patch-channel-store-methods.js')(dc);
 }
 
 module.exports = dc;

--- a/dc-polyfill.js
+++ b/dc-polyfill.js
@@ -19,7 +19,7 @@ if (!checks.hasChUnsubscribeReturn()) {
   dc = require('./patch-channel-unsubscribe-return.js')(dc);
 }
 
-if (VERSION < 18.0) {
+if ((VERSION < 18.19) || (VERSION >= 19.0 && VERSION < 19.8)) {
   if (!checks.hasChannelStoreMethods()) {
     dc = require('./patch-channel-store-methods.js')(dc);
   }
@@ -37,6 +37,7 @@ if (VERSION < 18.0) {
   }
   
 } else {
+  console.log('this is not running', VERSION >= 18.0 && VERSION < 18.19)
   if (!checks.hasTracingChannel()) {
     dc = require('./patch-tracing-channel.js')(dc);
   }
@@ -53,5 +54,6 @@ if (VERSION < 18.0) {
     dc = require('./patch-channel-store-methods.js')(dc);
   }
 }
+
 
 module.exports = dc;

--- a/dc-polyfill.js
+++ b/dc-polyfill.js
@@ -1,4 +1,5 @@
 const checks = require('./checks.js');
+const VERSION = checks.VERSION
 
 require('./primordials.js');
 
@@ -18,21 +19,39 @@ if (!checks.hasChUnsubscribeReturn()) {
   dc = require('./patch-channel-unsubscribe-return.js')(dc);
 }
 
-if (!checks.hasTracingChannel()) {
-  dc = require('./patch-tracing-channel.js')(dc);
-}
+if (VERSION < 18.0) {
+  if (!checks.hasChannelStoreMethods()) {
+    dc = require('./patch-channel-store-methods.js')(dc);
+  }
 
-if (checks.hasSyncUnsubscribeBug()) {
-  dc = require('./patch-sync-unsubscribe-bug.js')(dc);
-}
-
-if (!checks.hasTracingChannelHasSubscribers()) {
-  dc = require('./patch-tracing-channel-has-subscribers.js')(dc);
-}
-
-if (!checks.hasChannelStoreMethods()) {
-  dc = require('./patch-channel-store-methods.js')(dc);
+  if (!checks.hasTracingChannel()) {
+    dc = require('./patch-tracing-channel.js')(dc);
+  }
+  
+  if (checks.hasSyncUnsubscribeBug()) {
+    dc = require('./patch-sync-unsubscribe-bug.js')(dc);
+  }
+  
+  if (!checks.hasTracingChannelHasSubscribers()) {
+    dc = require('./patch-tracing-channel-has-subscribers.js')(dc);
+  }
+  
+} else {
+  if (!checks.hasTracingChannel()) {
+    dc = require('./patch-tracing-channel.js')(dc);
+  }
+  
+  if (checks.hasSyncUnsubscribeBug()) {
+    dc = require('./patch-sync-unsubscribe-bug.js')(dc);
+  }
+  
+  if (!checks.hasTracingChannelHasSubscribers()) {
+    dc = require('./patch-tracing-channel-has-subscribers.js')(dc);
+  }
+  
+  if (!checks.hasChannelStoreMethods()) {
+    dc = require('./patch-channel-store-methods.js')(dc);
+  }
 }
 
 module.exports = dc;
-


### PR DESCRIPTION
This is to reorder the conditionals for dc-polyfill in order to run stores after checking for subscribers. 