### PR TITLE
support destructured importing via esm

### DIFF
--- a/dc-polyfill.mjs
+++ b/dc-polyfill.mjs
@@ -1,0 +1,12 @@
+import * as dc from './dc-polyfill.js';
+
+export default dc;
+
+export const {
+  Channel,
+  channel,
+  hasSubscribers,
+  subscribe,
+  tracingChannel,
+  unsubscribe
+} = dc;

--- a/package.json
+++ b/package.json
@@ -3,6 +3,10 @@
   "version": "0.1.6",
   "description": "A polyfill for the internal diagnostics_channel module",
   "main": "dc-polyfill.js",
+  "exports": {
+    "require": "./dc-polyfill.js",
+    "import": "./dc-polyfill.mjs"
+  },
   "scripts": {
     "test": "./test.sh",
     "lint": "eslint .",

--- a/test/esm.spec.js
+++ b/test/esm.spec.js
@@ -1,0 +1,18 @@
+const test = require('tape');
+const fs = require('fs');
+const os = require('os');
+const execSync = require('child_process').execSync;
+
+test('esm', t => {
+  const tmpdir = os.tmpdir();
+  const basedir = fs.mkdtempSync(`${tmpdir}/esm-`);
+  const polyfillDir = process.cwd();
+  process.chdir(basedir);
+  execSync('npm init -y');
+  execSync('npm install ' + polyfillDir);
+  fs.writeFileSync('esm.mjs', `import { tracingChannel } from 'dc-polyfill'`);
+  t.doesNotThrow(() => execSync('node esm.mjs'));
+  process.chdir(polyfillDir);
+  execSync('rm -rf ' + basedir);
+  t.end();
+});


### PR DESCRIPTION
With a CJS file only, there was no way for Node.js to determine its exports, since they're created dynamically.

Adding an ESM file to re-export everything allows Node.js to correctly determine the exports.