### PR TITLE
Fix hasSubscribers when channel only has bindStore subscriptions in node <=20

### DIFF
--- a/patch-channel-store-methods.js
+++ b/patch-channel-store-methods.js
@@ -1,4 +1,8 @@
-const { ReflectApply } = require('./primordials.js');
+const { 
+  ReflectApply,
+  ObjectDefineProperty,
+  ObjectGetOwnPropertyDescriptor
+} = require('./primordials.js');
 
 module.exports = function (unpatched) {
   const channels = new WeakSet();
@@ -47,6 +51,14 @@ module.exports = function (unpatched) {
 
       return run();
     };
+
+    if (!ObjectGetOwnPropertyDescriptor(ch, 'hasSubscribers')) {
+      ObjectDefineProperty(ch, 'hasSubscribers', {
+        get: function() {
+            return this.__proto__.hasSubscribers || ch._stores.size > 0;
+          }
+      });
+    }
 
     channels.add(ch);
 

--- a/patch-garbage-collection-bug.js
+++ b/patch-garbage-collection-bug.js
@@ -27,7 +27,9 @@ module.exports = function(unpatched) {
         get: function() {
           const subscribers = ch._subscribers;
           if (subscribers.length > 1) return true;
-          if (subscribers.length < 1) return false;
+          const stores = ch._stores;
+          if (stores.size > 0) return true;
+          if (subscribers.length < 1 ) return false;
           if (subscribers[0] === PHONY_SUBSCRIBE) return false;
           return true;
         },

--- a/test/diagnostics-channel-store-has-subscribers.spec.js
+++ b/test/diagnostics-channel-store-has-subscribers.spec.js
@@ -1,0 +1,41 @@
+'use strict';
+
+const test = require('tape');
+
+const { channel, hasSubscribers } = require('../dc-polyfill.js');
+
+const { MAJOR, MINOR } = require('../checks.js');
+
+test('diagnostics-channel-store-has-subscribers', t => {
+  if (MAJOR === 15 && MINOR === 1) {
+    // node:diagnostics_channel:110
+    // if (ref) channel = WeakRefPrototypeGet(ref);
+    // TypeError: WeakRefPrototypeGet is not a function
+    t.comment('SKIPPING TEST DUE TO A BUG IN THIS VERSION OF NODE.JS');
+    t.end();
+    return;
+  }
+
+  const dc = channel('diagnostics-channel-store-has-subscribers');
+  t.ok(!hasSubscribers('diagnostics-channel-store-has-subscribers'));
+
+  const store = {};
+  dc.bindStore(store);
+  t.ok(hasSubscribers('diagnostics-channel-store-has-subscribers'));
+
+  dc.unbindStore(store);
+  t.ok(!hasSubscribers('diagnostics-channel-store-has-subscribers'));
+
+  const handler = () => {};
+  dc.bindStore(store);
+  dc.subscribe(handler);
+  t.ok(hasSubscribers('diagnostics-channel-store-has-subscribers'));
+
+  dc.unsubscribe(handler);
+  t.ok(hasSubscribers('diagnostics-channel-store-has-subscribers'));
+
+  dc.unbindStore(store);
+  t.ok(!hasSubscribers('diagnostics-channel-store-has-subscribers'));
+
+  t.end();
+});

--- a/test/test-diagnostics-channel-has-subscribers.spec.js
+++ b/test/test-diagnostics-channel-has-subscribers.spec.js
@@ -19,14 +19,14 @@ test('test-diagnostics-channel-has-subscribers', t => {
   const dc = channel('test-diagnostics-channel-has-subscribers');
   t.ok(!hasSubscribers('test-diagnostics-channel-has-subscribers'));
 
-  const handler = () => {}
+  const handler = () => {};
   dc.subscribe(handler);
   t.ok(hasSubscribers('test-diagnostics-channel-has-subscribers'));
 
   dc.unsubscribe(handler);
   t.ok(!hasSubscribers('test-diagnostics-channel-has-subscribers'));
 
-  const store = {}
+  const store = {};
   dc.bindStore(store);
   t.ok(hasSubscribers('test-diagnostics-channel-has-subscribers'));
 

--- a/test/test-diagnostics-channel-has-subscribers.spec.js
+++ b/test/test-diagnostics-channel-has-subscribers.spec.js
@@ -19,19 +19,7 @@ test('test-diagnostics-channel-has-subscribers', t => {
   const dc = channel('test-diagnostics-channel-has-subscribers');
   t.ok(!hasSubscribers('test-diagnostics-channel-has-subscribers'));
 
-  const handler = () => {};
-  dc.subscribe(handler);
+  dc.subscribe(() => {});
   t.ok(hasSubscribers('test-diagnostics-channel-has-subscribers'));
-
-  dc.unsubscribe(handler);
-  t.ok(!hasSubscribers('test-diagnostics-channel-has-subscribers'));
-
-  const store = {};
-  dc.bindStore(store);
-  t.ok(hasSubscribers('test-diagnostics-channel-has-subscribers'));
-
-  dc.unbindStore(store);
-  t.ok(!hasSubscribers('test-diagnostics-channel-has-subscribers'));
-
   t.end();
 });

--- a/test/test-diagnostics-channel-has-subscribers.spec.js
+++ b/test/test-diagnostics-channel-has-subscribers.spec.js
@@ -19,7 +19,19 @@ test('test-diagnostics-channel-has-subscribers', t => {
   const dc = channel('test-diagnostics-channel-has-subscribers');
   t.ok(!hasSubscribers('test-diagnostics-channel-has-subscribers'));
 
-  dc.subscribe(() => {});
+  const handler = () => {}
+  dc.subscribe(handler);
   t.ok(hasSubscribers('test-diagnostics-channel-has-subscribers'));
+
+  dc.unsubscribe(handler);
+  t.ok(!hasSubscribers('test-diagnostics-channel-has-subscribers'));
+
+  const store = {}
+  dc.bindStore(store);
+  t.ok(hasSubscribers('test-diagnostics-channel-has-subscribers'));
+
+  dc.unbindStore(store);
+  t.ok(!hasSubscribers('test-diagnostics-channel-has-subscribers'));
+
   t.end();
 });


### PR DESCRIPTION
Using Node.js diagnostics_channel, this code returns `true`:

```javascript
const diagnostics_channel = require('node:diagnostics_channel');
// const diagnostics_channel = require('dc-polyfill')
const channel = diagnostics_channel.channel('my-channel');
const store = {}

channel.bindStore(store, () => {});

console.log('channel.hasSubscribers', channel.hasSubscribers)
```
But if `node:diagnostics_channel` is replaced by `dc-polyfill`, it returns `false` in node 18. 

This PR want to fix that.